### PR TITLE
worker: silence connection retry on startup warning

### DIFF
--- a/worker.py
+++ b/worker.py
@@ -15,4 +15,5 @@ app = Celery(
         "data_folder_out": path,
     },
     imports=("tasks",),
+    broker_connection_retry_on_startup=True,
 )


### PR DESCRIPTION
Starting the example throws this warning:

  [2024-10-06 12:11:03,270: WARNING/MainProcess] .../env/lib/python3.11/site-packages/celery/worker/consumer/consumer.py:508:
  CPendingDeprecationWarning: The broker_connection_retry configuration setting will no longer determine
  whether broker connection retries are made during startup in Celery 6.0 and above.
  If you wish to retain the existing behavior for retrying connections on startup,
  you should set broker_connection_retry_on_startup to True.
    warnings.warn(

So let's set follow the advise and set broker_connection_retry_on_startup to True.